### PR TITLE
Fix Twitter Intent on SpeakerDetailView

### DIFF
--- a/android/app/src/main/kotlin/com/chicagoroboto/features/speakerdetail/SpeakerDetailView.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/speakerdetail/SpeakerDetailView.kt
@@ -78,7 +78,7 @@ class SpeakerDetailView(context: Context, attrs: AttributeSet? = null, defStyle:
 
           twitter.setOnClickListener {
               val twitterIntent = Intent(Intent.ACTION_VIEW).apply {
-                  data = Uri.parse("https://www.twitter.com/${speaker.twitter}")
+                  data = Uri.parse("https://www.twitter.com/${speaker.twitter?.removePrefix("@")}")
               }
               context.startActivity(twitterIntent)
           }


### PR DESCRIPTION
- Fix the Twitter URL Intent by not including the ‘@‘ at the beginning if it exists.