### PR TITLE
Collapsing header title bugfix

### DIFF
--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SessionDetailView.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SessionDetailView.kt
@@ -1,8 +1,8 @@
 package com.chicagoroboto.features.sessiondetail
 
-import android.app.Activity
 import android.content.Context
 import android.support.design.widget.CoordinatorLayout
+import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.LinearLayoutManager
 import android.text.format.DateUtils
 import android.util.AttributeSet
@@ -16,7 +16,7 @@ import com.chicagoroboto.model.Session
 import com.chicagoroboto.model.Speaker
 import com.chicagoroboto.utils.DrawableUtils
 import kotlinx.android.synthetic.main.view_session_detail.view.*
-import java.util.Date
+import java.util.*
 import javax.inject.Inject
 
 class SessionDetailView(context: Context, attrs: AttributeSet? = null, defStyle: Int = 0) :
@@ -36,11 +36,6 @@ class SessionDetailView(context: Context, attrs: AttributeSet? = null, defStyle:
         context.getComponent<SessionDetailComponent>().inject(this)
 
         LayoutInflater.from(context).inflate(R.layout.view_session_detail, this, true)
-        toolbar.setNavigationOnClickListener {
-            if (context is Activity) {
-                context.finish()
-            }
-        }
 
         speakerAdapter = SpeakerAdapter(avatarProvider, true, { speaker, image ->
             speakerNavigator.navigateToSpeaker(speaker.id!!, image)
@@ -72,6 +67,11 @@ class SessionDetailView(context: Context, attrs: AttributeSet? = null, defStyle:
 
     override fun showSessionDetail(session: Session) {
         toolbar.title = session.title
+        val activity = context as? AppCompatActivity
+        activity?.setSupportActionBar(toolbar)
+        toolbar.setNavigationOnClickListener {
+            activity?.finish()
+        }
 
         val startTime = DateUtils.formatDateTime(context, session.startTime?.time ?: 0,
             DateUtils.FORMAT_SHOW_TIME)

--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SessionDetailView.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SessionDetailView.kt
@@ -16,7 +16,7 @@ import com.chicagoroboto.model.Session
 import com.chicagoroboto.model.Speaker
 import com.chicagoroboto.utils.DrawableUtils
 import kotlinx.android.synthetic.main.view_session_detail.view.*
-import java.util.*
+import java.util.Date
 import javax.inject.Inject
 
 class SessionDetailView(context: Context, attrs: AttributeSet? = null, defStyle: Int = 0) :

--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SessionDetailView.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SessionDetailView.kt
@@ -67,10 +67,10 @@ class SessionDetailView(context: Context, attrs: AttributeSet? = null, defStyle:
 
     override fun showSessionDetail(session: Session) {
         toolbar.title = session.title
-        val activity = context as? AppCompatActivity
-        activity?.setSupportActionBar(toolbar)
+        val activity = context as AppCompatActivity
+        activity.setSupportActionBar(toolbar)
         toolbar.setNavigationOnClickListener {
-            activity?.finish()
+            activity.finish()
         }
 
         val startTime = DateUtils.formatDateTime(context, session.startTime?.time ?: 0,


### PR DESCRIPTION
was seeing this layout bug pretty frequently on Nougat 
<img width="347" alt="screen shot 2018-04-11 at 9 02 23 pm" src="https://user-images.githubusercontent.com/17131236/38654366-83e2152e-3dd4-11e8-85b7-e52f079fb075.png">
mentioned here: https://stackoverflow.com/questions/42464522/when-running-on-nougat-why-does-the-title-gets-cut-off-when-using-a-collapsingt

using `setSupportActionBar` seems to fix it, but you need to set the title first so I moved the toolbar initialization after that was happening in `showSessionDetail`