### PR TITLE
make technical feedback more clear

### DIFF
--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/feedback/FeedbackDialog.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/feedback/FeedbackDialog.kt
@@ -11,6 +11,7 @@ import com.chicagoroboto.features.sessiondetail.SessionDetailComponent
 import com.chicagoroboto.model.Feedback
 import kotlinx.android.synthetic.main.dialog_feedback.view.*
 import javax.inject.Inject
+import kotlin.math.roundToInt
 
 class FeedbackDialog(context: Context, val sessionId: String) : Dialog(context, true, null), FeedbackMvp.View {
 
@@ -25,7 +26,7 @@ class FeedbackDialog(context: Context, val sessionId: String) : Dialog(context, 
 
         view = LayoutInflater.from(context).inflate(R.layout.dialog_feedback, null, false)
         view.submit.setOnClickListener {
-            presenter.submit(view.overall.rating, view.technical.rating, view.speaker.rating)
+            presenter.submit(view.overall.rating, view.technical.progress.toFloat(), view.speaker.rating)
         }
 
         view.cancel.setOnClickListener {
@@ -47,7 +48,7 @@ class FeedbackDialog(context: Context, val sessionId: String) : Dialog(context, 
 
     override fun setFeedback(feedback: Feedback) {
         view.overall.rating = feedback.overall ?: 0f
-        view.technical.rating = feedback.technical ?: 0f
+        view.technical.progress = feedback.technical?.roundToInt() ?: 0
         view.speaker.rating = feedback.speaker ?: 0f
     }
 }

--- a/android/app/src/main/res/drawable/ic_technical_thumb.xml
+++ b/android/app/src/main/res/drawable/ic_technical_thumb.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="?attr/colorControlActivated" />
+    <size
+        android:width="6dp"
+        android:height="24dp" />
+    <corners android:radius="2dp" />
+</shape>

--- a/android/app/src/main/res/drawable/ic_technical_tick.xml
+++ b/android/app/src/main/res/drawable/ic_technical_tick.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+
+    <solid android:color="#fff"/>
+    <size
+        android:width="8dp"
+        android:height="8dp" />
+</shape>

--- a/android/app/src/main/res/layout/dialog_feedback.xml
+++ b/android/app/src/main/res/layout/dialog_feedback.xml
@@ -1,71 +1,127 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
-    <LinearLayout
+
+    <android.support.constraint.ConstraintLayout
         android:id="@+id/container_ratings"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingTop="16dp"
         android:paddingBottom="16dp"
         android:paddingLeft="16dp"
-        android:paddingRight="16dp">
+        android:paddingRight="16dp"
+        android:paddingTop="16dp">
+
         <TextView
+            android:id="@+id/feedback_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
-            android:textAppearance="?android:textAppearanceLarge"
-            android:text="@string/feedback_title"/>
+            android:text="@string/feedback_title"
+            android:textAppearance="?android:textAppearanceLarge" />
+
         <TextView
+            android:id="@+id/overall_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:text="@string/feedback_session"
             android:textAppearance="?android:textAppearanceMedium"
-            android:text="@string/feedback_session"/>
+            app:layout_constraintTop_toBottomOf="@id/feedback_title" />
+
         <RatingBar
             android:id="@+id/overall"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:numStars="5"/>
+            android:numStars="5"
+            app:layout_constraintTop_toBottomOf="@id/overall_title" />
+
+        <TextView
+            android:id="@+id/technical_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/feedback_content"
+            android:textAppearance="?android:textAppearanceMedium"
+            app:layout_constraintTop_toBottomOf="@id/overall" />
+
+        <TextView
+            android:id="@+id/technical_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/not_enough"
+            android:textColor="?attr/colorControlActivated"
+            app:layout_constraintTop_toBottomOf="@id/technical_title" />
+
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textAppearance="?android:textAppearanceMedium"
-            android:text="@string/feedback_content"/>
-        <RatingBar
+            android:text="@string/just_right"
+            android:textColor="?attr/colorControlActivated"
+            app:layout_constraintLeft_toLeftOf="@id/technical"
+            app:layout_constraintRight_toRightOf="@id/technical"
+            app:layout_constraintTop_toBottomOf="@id/technical_title" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="end"
+            android:text="@string/too_much"
+            android:textColor="?attr/colorControlActivated"
+            app:layout_constraintRight_toRightOf="@id/technical"
+            app:layout_constraintTop_toBottomOf="@id/technical_title" />
+
+        <android.support.v7.widget.AppCompatSeekBar
             android:id="@+id/technical"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:numStars="5"/>
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:max="4"
+            android:maxHeight="48dp"
+            android:progress="2"
+            android:progressBackgroundTint="?attr/colorControlActivated"
+            android:progressBackgroundTintMode="src_over"
+            android:progressTint="?attr/colorControlActivated"
+            android:thumb="@drawable/ic_technical_thumb"
+            app:layout_constraintLeft_toLeftOf="@id/overall"
+            app:layout_constraintRight_toRightOf="@id/overall"
+            app:layout_constraintTop_toBottomOf="@id/technical_label"
+            app:tickMark="@drawable/ic_technical_tick"
+            app:tickMarkTint="?attr/colorControlActivated" />
+
         <TextView
+            android:id="@+id/speaker_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:text="@string/feedback_speaker"
             android:textAppearance="?android:textAppearanceMedium"
-            android:text="@string/feedback_speaker"/>
+            app:layout_constraintTop_toBottomOf="@id/technical" />
+
         <RatingBar
             android:id="@+id/speaker"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:numStars="5"/>
-    </LinearLayout>
+            android:numStars="5"
+            app:layout_constraintTop_toBottomOf="@id/speaker_title" />
+    </android.support.constraint.ConstraintLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="end"
         android:orientation="horizontal">
+
         <Button
             android:id="@+id/cancel"
             style="@style/Widget.AppCompat.Button.Borderless.Colored"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/cancel"/>
+            android:text="@string/cancel" />
+
         <Button
             android:id="@+id/submit"
             style="@style/Widget.AppCompat.Button.Borderless.Colored"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/submit"/>
+            android:text="@string/submit" />
     </LinearLayout>
 </LinearLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -24,5 +24,8 @@
     <string name="cd_logo">Event Logo</string>
     <string name="note_feedback_title">%1$s complete</string>
     <string name="note_feedback_msg">Don\'t forget to submit feedback.</string>
-  <string name="feedback_note_channel">Session Feedback</string>
+    <string name="feedback_note_channel">Session Feedback</string>
+    <string name="not_enough">Not\nenough</string>
+    <string name="just_right">Just\nright</string>
+    <string name="too_much">Too\nmuch</string>
 </resources>

--- a/android/feedback/README.md
+++ b/android/feedback/README.md
@@ -7,7 +7,7 @@ Feedback submitted in the app will be entered in the web into a `feedback` colle
   "[talk-id]": {
     "[user-id]": {
       "overall": [0-5],
-      "technical": [0-5],
+      "technical": [0-4],
       "speaker": [0-5]
     },
     ...


### PR DESCRIPTION
Addresses #30.

Change the UI for the feedback on technical level of the session
to make it clear what the rating means (i.e. was the session too
technical, not technical enough, or just right)

![image](https://user-images.githubusercontent.com/1413600/38786938-fefbfabe-40f8-11e8-8448-623cf473e671.png)

Note that this changes the scale of the technical rating from 0-5 to 0-4:

```
0 = Not technical enough
1
2 = Just right
3
4 = Too technical
```
