### PR TITLE
Maintain list state after config change

### DIFF
--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessions/SessionDateFragment.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessions/SessionDateFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
-import com.chicagoroboto.R
 import com.chicagoroboto.databinding.SessionsBinding
 import com.chicagoroboto.ext.getComponent
 import com.chicagoroboto.ext.presentations
@@ -42,8 +41,6 @@ class SessionDateFragment : Fragment() {
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
-    binding.pager.adapter = adapter
-    adapter.mediateTabs(binding.tabs, binding.pager)
 
     binding.appBar.doOnApplyWindowInsets { view, insets, initialState ->
       view.updatePadding(
@@ -63,6 +60,9 @@ class SessionDateFragment : Fragment() {
         adapter.dates.clear()
         adapter.dates.addAll(it.dates)
         adapter.notifyDataSetChanged()
+
+        binding.pager.adapter = adapter
+        adapter.mediateTabs(binding.tabs, binding.pager)
 
         // Set the current tab to today
         if (it.dates.isNotEmpty()) {

--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessions/SessionDateFragment.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessions/SessionDateFragment.kt
@@ -64,12 +64,14 @@ class SessionDateFragment : Fragment() {
         binding.pager.adapter = adapter
         adapter.mediateTabs(binding.tabs, binding.pager)
 
-        // Set the current tab to today
-        if (it.dates.isNotEmpty()) {
-          val today = dateFormat.format(Date())
-          val index = adapter.dates.indexOfFirst { it.id == today }
-          if (index >= 0) {
-            binding.pager.setCurrentItem(index, false)
+        if (savedInstanceState == null) {
+          // Set the current tab to today
+          if (it.dates.isNotEmpty()) {
+            val today = dateFormat.format(Date())
+            val index = adapter.dates.indexOfFirst { it.id == today }
+            if (index >= 0) {
+              binding.pager.setCurrentItem(index, false)
+            }
           }
         }
       }

--- a/android/data.json
+++ b/android/data.json
@@ -181,7 +181,7 @@
     "-L-2S4rWWRVi2OlUEpRR" : {
       "abstract" : "Mark Allison (author of https://blog.stylingandroid,com) has a deep love of VectorDrawable. He has spoken at conferences about how to construct and Animate them in his talk entitled \"Vector All The Things\".\n\nIn this all new talk, Mark will look at some of the features which have been added to VectorDrawable and its sibling AnimatedVectorDrawable since they first appeared in Android Lollipop 5.0 (API 21). There will be a dive in to fill windings which can cause some baffling rendering oddities, yet can be quite simple to fix once you recognise that fill windings are the cause; There will also be a look at the recently added gradient support; And, of course, there will be plenty of tricks and tips to help with your creation of fabulous VectorDrawables, and amazing Animations.",
       "start_time": "2018-04-12T14:00:00-0500",
-      "end_time": "2018-04-1214:45:00-0500",
+      "end_time": "2018-04-12T14:45:00-0500",
       "date" : "2018-04-12",
       "accepted" : true,
       "duration" : 40,


### PR DESCRIPTION
- Move setting of pager adapter so that list fragment state is restored after config change

  - After a config change (such as screen rotation), a ViewPager2's state is restored when its adapter is set. If the adapter is set before the backing data is set, then each of the ViewPager2's page Fragment's states won't be restored as expected. By moving the setting of the adapter after the adapter's data is set, it allows the currently selected tab to be restored as well as the scroll position of the RecyclerViews in the list Fragments.

- Set the current tab to today only once on startup so that after a config change, it won't change the user's currently selected tab

- Fix date string